### PR TITLE
update OWNERS and add a NOTICE for cla exceptions

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+When donating the apisnoop project to the CNCF, not all contributors were reached
+to sign the CNCF CLA prior to donation. As such, according to the CNCF rules to donate a repository,
+we must add a NOTICE referencing section 7 of the CLA with a list of developers who could not be reached.
+
+`7. Should You wish to submit work that is not Your original creation, You may
+submit it to the Foundation separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".`
+
+Submitted on behalf of a third-party: @jamesgrafas
+Submitted on behalf of a third-party: @midopooler

--- a/OWNERS
+++ b/OWNERS
@@ -5,4 +5,3 @@ approvers:
   - cooldracula
   - heyste
   - hh
-  - zachmandeville

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -14,4 +14,3 @@ BobyMCbobs
 cooldracula
 heyste
 hh
-zachmandeville


### PR DESCRIPTION
Finishing setup of the repo
Ref https://github.com/kubernetes/org/issues/4705

1. Updating OWNERS files to reflect folks who are part of the GitHub orgs
2. Adding a NOTICE file for folks who have not signed the CNCF CLA as per [guidelines](https://github.com/kubernetes/community/blob/master/github-management/kubernetes-repositories.md#rules-for-donated-repositories)

/hold 