### PR TITLE
chore: remove weekly updater commit sign off

### DIFF
--- a/.github/workflows/apisnoop_weekly_updater.yml
+++ b/.github/workflows/apisnoop_weekly_updater.yml
@@ -51,6 +51,6 @@ jobs:
           git add resources/coverage/*.json
           git branch "${NEW_BRANCH}"
           git checkout "${NEW_BRANCH}"
-          git commit -s -m "chore: update coverage for ${TIMESTAMP}" -m "updates coverage metadata for ${TIMESTAMP}"
+          git commit -m "chore: update coverage for ${TIMESTAMP}" -m "updates coverage metadata for ${TIMESTAMP}"
           git push origin "${NEW_BRANCH}"
           gh pr create --title "Update APISnoop coverage ${TIMESTAMP}" --body "updates to coverage for ${TIMESTAMP}"


### PR DESCRIPTION
no need to sign-off commits given no cncf cla bot