### PR TITLE
Call out that this is an ERROR explicitly

### DIFF
--- a/apps/snoopdb/postgres/docker-entrypoint.sh
+++ b/apps/snoopdb/postgres/docker-entrypoint.sh
@@ -187,7 +187,7 @@ else
 	echo
     UNTESTED=$(wc -l /tmp/untested-endpoints.txt | cut -d" " -f1)
     echo '=================='
-    echo "You have ${UNTESTED} untested endpoints"
+    echo "ERROR: You have ${UNTESTED} untested endpoints"
     echo '=================='
 	if [ $UNTESTED -eq 0 ]; then
 		exit 0


### PR DESCRIPTION
if we tag this as an ERROR, then there's a chance that it will show up better in https://storage.googleapis.com/k8s-triage/index.html?ci=0&pr=1 and it will get highlighted here https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/apisnoop-conformance-gate/1766420887134801920