### PR TITLE
fix: switch to ec2 bucket

### DIFF
--- a/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
@@ -1,6 +1,6 @@
 begin;
 select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
-select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
+select * from load_audit_events('ci-kubernetes-ec2-conformance-latest') f("build log");
 select * from load_audit_events('ci-audit-kind-conformance') f("build log");
 call update_pod_binding_events();
 commit;

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -18,7 +18,7 @@ import glob
 from pathlib import Path
 
 AKC_BUCKET="ci-audit-kind-conformance"
-KGCL_BUCKET="ci-kubernetes-gce-conformance-latest"
+KGCL_BUCKET="ci-kubernetes-ec2-conformance-latest"
 KEGG_BUCKET="ci-kubernetes-e2e-gci-gce"
 
 AUDIT_KIND_CONFORMANCE_RUNS="https://prow.k8s.io/job-history/kubernetes-jenkins/logs/ci-audit-kind-conformance"


### PR DESCRIPTION
The Conformance Gate (which uses apisnoop) https://testgrid.k8s.io/sig-arch-conformance#apisnoop-conformance-gate&width=5 has been failing, 

```
                                   build log                                   
------------------------------------------------------------------------------
 events for 1.30.0 loaded, from ci-kubernetes-e2e-gci-gce/1770094608252932096
(1 row)
2024-03-19 15:40:56.580 UTC [126] ERROR:  urllib.error.HTTPError: HTTP Error 500: Internal Server Error
2024-03-19 15:40:56.580 UTC [126] CONTEXT:  Traceback (most recent call last):
	  PL/Python function "load_audit_events", line 14, in <module>
	    meta = get_meta(bucket,custom_job)
	  PL/Python function "load_audit_events", line 483, in get_meta
	  PL/Python function "load_audit_events", line 412, in kgcl_meta
	  PL/Python function "load_audit_events", line 560, in error
	  PL/Python function "load_audit_events", line 493, in _call_chain
	  PL/Python function "load_audit_events", line 640, in http_error_default
	PL/Python function "load_audit_events"
2024-03-19 15:40:56.580 UTC [126] STATEMENT:  select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log"); 
```

@cooldracula found it is happening when we try to get the test runs for `ci-kubernetes-gce-conformance-latest`
https://prow.k8s.io/job-history/kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest

```
failed to get job history: failed to locate build data: failed to read logs/ci-kubernetes-gce-conformance-latest/latest-build.txt: creating reader for object logs/ci-kubernetes-gce-conformance-latest/latest-build.txt: storage: object doesn't exist
```

This job has been migrated from gce to ec2.
https://prow.k8s.io/job-history/kubernetes-jenkins/logs/ci-kubernetes-ec2-conformance-latest

Switching to the new bucket should fix APIsnoop. 