### PR TITLE
fix invalid commit message for github action: Update Kubernetes version

### DIFF
--- a/.github/workflows/update-kubernetes-release-version.yml
+++ b/.github/workflows/update-kubernetes-release-version.yml
@@ -45,6 +45,6 @@ jobs:
           git add resources/coverage/releases.yaml
           git branch "${NEW_BRANCH}"
           git checkout "${NEW_BRANCH}"
-          git commit -s -m "update Kubernetes version for ${TIMESTAMP}"
+          git commit -m "update Kubernetes version for ${TIMESTAMP}"
           git push origin "${NEW_BRANCH}"
           gh pr create --title "Update Kubernetes version ${TIMESTAMP}" --body "updates to Kubernetes version for ${TIMESTAMP}"


### PR DESCRIPTION
The github action: "Update Kubernetes version" wants to create a PR (due to release last week), the k8s prow bot is currently adding "do-not-merge/invalid-commit-message" label to the pr.

By removing the "commit sign off" from the github action future prs should be acceptable to the prow bot.
