### PR TITLE
chore: bump charts to v1.2.13 and v1.4.5

### DIFF
--- a/charts/auditlogger/Chart.yaml
+++ b/charts/auditlogger/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.12
+version: 1.2.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v20240109-snoopdb-1.4.2-51-g8e47559
+appVersion: v20240626-auditlogger-1.2.12-4-g80e96ac

--- a/charts/snoopdb/Chart.yaml
+++ b/charts/snoopdb/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.4
+version: 1.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v20240109-snoopdb-1.4.2-51-g8e47559
+appVersion: v20240626-auditlogger-1.2.12-4-g80e96ac


### PR DESCRIPTION
use updated app versions