### PR TITLE
fix formatting for untested endpoint results

### DIFF
--- a/apps/snoopdb/postgres/docker-entrypoint.sh
+++ b/apps/snoopdb/postgres/docker-entrypoint.sh
@@ -183,15 +183,17 @@ if [ -z "$JOB_NAME" ]; then
 else
     echo '=================='
     echo 'UNTESTED ENDPOINTS'
-	cat /tmp/untested-endpoints.txt
-	echo
+    cat /tmp/untested-endpoints.txt
+    echo
+    echo '=================='
     UNTESTED=$(wc -l /tmp/untested-endpoints.txt | cut -d" " -f1)
-    echo '=================='
-    echo "ERROR: You have ${UNTESTED} untested endpoints"
-    echo '=================='
-	if [ $UNTESTED -eq 0 ]; then
-		exit 0
-	else
-	    exit 1
-	fi
+    if [ $UNTESTED -eq 0 ]; then
+        echo "You have ${UNTESTED} untested endpoints"
+        echo '=================='
+        exit 0
+    else
+        echo "ERROR: You have ${UNTESTED} untested endpoints"
+        echo '=================='
+        exit 1
+    fi
 fi


### PR DESCRIPTION
When there are no untested endpoints the current logging is misleading as seen in the current [apisnoop-conformance-gate](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/apisnoop-conformance-gate) results

```
==================
UNTESTED ENDPOINTS
==================
ERROR: You have 0 untested endpoints
================== 
```

When there are no untested endpoints the new output log
```
==================
UNTESTED ENDPOINTS
==================
You have 0 untested endpoints
================== 
```
