### PR TITLE
Remove --kube-root deprecated kind argument

### DIFF
--- a/org/kind+auditsink.org
+++ b/org/kind+auditsink.org
@@ -567,7 +567,7 @@ This can take a while, and you can allocate more CPU and memory to your docker V
 
 #+begin_src tmate
   ls -la ~/go/src/k8s.io/kubernetes
-  kind build node-image --kube-root ~/go/src/k8s.io/kubernetes
+  kind build node-image ~/go/src/k8s.io/kubernetes
 #+end_src
 
 ** kind image


### PR DESCRIPTION
The `--kube-root` flag has been deprecated in kind for some time and will be removed. The current equivalent functionality is to pass the path to the kubernetes source as the first non-flag argument to `build node-image`.

This updates the kind instructions to use the newer preferred method in preparation for kind dropping the flag.

Related: https://github.com/kubernetes-sigs/kind/issues/3717