### PR TITLE
chore: update weekly updater image to 20241203

### DIFF
--- a/.github/workflows/apisnoop_weekly_updater.yml
+++ b/.github/workflows/apisnoop_weekly_updater.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 12 * * 6"
 
 env:
-  IMAGE: gcr.io/k8s-staging-apisnoop/snoopdb:v20240121-auditlogger-1.2.11-4-gb17b29c
+  IMAGE: gcr.io/k8s-staging-apisnoop/snoopdb:v20241203-auditlogger-1.2.13-44-g73987d8
 
 jobs:
   update:


### PR DESCRIPTION
use latest image that uses new bucket refs

https://github.com/kubernetes/k8s.io/issues/1310

image ref from https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/apisnoop-push-snoopdb-images/1864054260988121088