### PR TITLE
chore: use kubernetes-ci-logs in more places

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ Snoopdb uses the following sources for determining tested conformant endpoints:
 - The [[https://github.com/kubernetes/kubernetes/tree/master/api/openapi-spec][Kubernetes OpenAPI spec]], to determine all endpoints
 - The list of conformance tests at [[https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/conformance.yaml][kubernetes/kubernetes/test/conformance/testdata/conformance.yaml]]
 - The list of [[https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/ineligible_endpoints.yaml][endpoints ineligible for conformance]] in the same directory as above
-- The latest conformance suite test runs available via prow/testgrid ([[https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest/1705668219261423616][example]]).
+- The latest conformance suite test runs available via prow/testgrid ([[https://prow.k8s.io/view/gcs/kubernetes-ci-logs/logs/ci-kubernetes-gce-conformance-latest/1705668219261423616][example]]).
 
 We define "new conformance endpoints" as the endpoints in the most recent openAPI spec that are stable, not deprecated, and are not included in the ineligible-endpoints.yaml.
 

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -55,7 +55,7 @@
                   ((raw.data ->> 'userAgent') like 'e2e.test%') as test_hit,
                   ((raw.data ->> 'userAgent') like '%[Conformance]%') as conf_test_hit,
                   raw.data,
-                  'https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/${bucket}/${job}' as source
+                  'https://prow.k8s.io/view/gcs/kubernetes-ci-logs/logs/${bucket}/${job}' as source
             FROM audit_event_import${job} raw;
                   """).substitute(
                       audit_logfile = auditlog_file,

--- a/apps/web/src/components/Sunburst/Prologue.svelte
+++ b/apps/web/src/components/Sunburst/Prologue.svelte
@@ -4,7 +4,7 @@
  import SectionHeader from '../SectionHeader.svelte';
  import { activeRelease, releases, versions } from '../../store';
 
- const SPYGLASS_URL = 'https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs'
+ const SPYGLASS_URL = 'https://prow.k8s.io/view/gcs/kubernetes-ci-logs/logs'
  let releaseSwitch = false;
 
  $: ({

--- a/apps/web/src/pages/About.svelte
+++ b/apps/web/src/pages/About.svelte
@@ -85,7 +85,7 @@
   <li>
     <a href="https://github.com/kubernetes/kubernetes/tree/master/api/openapi-spec">The open api spec for Kubernetes</a>
   </li>
-  <li>Audit logs from an e2e test run that was run for this release(<a href="https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest/1278470809987321859">example test)</a></li>
+  <li>Audit logs from an e2e test run that was run for this release(<a href="https://prow.k8s.io/view/gcs/kubernetes-ci-logs/logs/ci-kubernetes-gce-conformance-latest/1278470809987321859">example test)</a></li>
 </ul>
 
 <p>


### PR DESCRIPTION
replacing kubernetes-jenkins in remaining active places