### PR TITLE
Update stable.txt url

### DIFF
--- a/cmd/update-kubernetes-release-version/main.go
+++ b/cmd/update-kubernetes-release-version/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	stableVersionURL       string = "https://storage.googleapis.com/kubernetes-release/release/stable.txt"
+	stableVersionURL       string = "https://dl.k8s.io/release/stable.txt"
 	kubernetesGitHubTagURL string = "https://api.github.com/repos/kubernetes/kubernetes/releases/tags"
 )
 


### PR DESCRIPTION
It looks like we need to update the URL for stable.txt file, the one on the googleapis is supposed to be gone (or not updated automatically any more).

The new URL is: https://dl.k8s.io/release/stable.txt

PS: I will create another PR to update it on `kubernetes-sigs/verify-conformance` repo as well.

/cc @BobyMCbobs 