### PR TITLE
Fix netcat package name, update snoopdb version

### DIFF
--- a/.github/workflows/apisnoop_weekly_updater.yml
+++ b/.github/workflows/apisnoop_weekly_updater.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 12 * * 6"
 
 env:
-  IMAGE: gcr.io/k8s-staging-apisnoop/snoopdb:v20241203-auditlogger-1.2.13-44-g73987d8
+  IMAGE: gcr.io/k8s-staging-apisnoop/snoopdb:v20250115-auditlogger-1.2.13-64-gf795789
 
 jobs:
   update:
@@ -20,7 +20,7 @@ jobs:
       - name: configure system
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y postgresql-client netcat
+          sudo apt-get install -y postgresql-client netcat-openbsd
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})


### PR DESCRIPTION
- Fix `netcat` package error for Ubuntu 24.04:

```bash
Package netcat is a virtual package provided by:
  netcat-traditional 1.10-48
  netcat-openbsd 1.226-1ubuntu2

E: Package 'netcat' has no installation candidate
Error: Process completed with exit code 100.
```

- Update snoopdb version