### PR TITLE
adjust for kubetest2 generated finished.json

### DIFF
--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -383,7 +383,7 @@ def kgcl_version(job):
     """
     finished_url = GCS_LOGS + KGCL_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"]["job-version"]
+    job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
 
     match = re.match("^v([0-9.]+)-",job_version)
     if match is None:
@@ -399,7 +399,7 @@ def kgcl_commit(job):
     # we want the end of the string, after the '+'. A commit should only be numbers and letters
     finished_url = GCS_LOGS + KGCL_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"]["job-version"]
+    job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
 
     match = re.match(".+\+([0-9a-zA-Z]+)$",job_version)
     if match is None:
@@ -442,7 +442,7 @@ def kegg_version(job):
     """
     finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"]["job-version"]
+    job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
 
     match = re.match("^v([0-9.]+)-",job_version)
     if match is None:
@@ -458,7 +458,7 @@ def kegg_commit(job):
     # we want the end of the string, after the '+'. A commit should only be numbers and letters
     finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"]["job-version"]
+    job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
     match = re.match(".+\+([0-9a-zA-Z]+)$",job_version)
     if match is None:
         raise ValueError("Could not find commit in given job_version.", job_version)


### PR DESCRIPTION
compare the finished.json from kubetest:
https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-gce-conformance-latest/1962084566873149440/finished.json

and the one from kubetest2:
https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-gce-conformance-latest/1962968736088461312/finished.json

`job-version` has been dropped in favor of `revision`.