### PR TITLE
WHOOPS! picked the wrong field

### DIFF
--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -383,7 +383,7 @@ def kgcl_version(job):
     """
     finished_url = GCS_LOGS + KGCL_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
+    job_version = finished["metadata"].get("job-version") or finished.get("revision")
 
     match = re.match("^v([0-9.]+)-",job_version)
     if match is None:
@@ -399,7 +399,7 @@ def kgcl_commit(job):
     # we want the end of the string, after the '+'. A commit should only be numbers and letters
     finished_url = GCS_LOGS + KGCL_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
+    job_version = finished["metadata"].get("job-version") or finished.get("revision")
 
     match = re.match(".+\+([0-9a-zA-Z]+)$",job_version)
     if match is None:
@@ -442,7 +442,7 @@ def kegg_version(job):
     """
     finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
+    job_version = finished["metadata"].get("job-version") or finished.get("revision")
 
     match = re.match("^v([0-9.]+)-",job_version)
     if match is None:
@@ -458,7 +458,7 @@ def kegg_commit(job):
     # we want the end of the string, after the '+'. A commit should only be numbers and letters
     finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
+    job_version = finished["metadata"].get("job-version") or finished.get("revision")
     match = re.match(".+\+([0-9a-zA-Z]+)$",job_version)
     if match is None:
         raise ValueError("Could not find commit in given job_version.", job_version)


### PR DESCRIPTION
Apologies! i got it wrong.

```
>>> finished = {'timestamp': 1756904846, 'passed': True, 'metadata': {'deployer-version': '9560e3922fc039b76e6f3bab9b9711c38ac6d486', 'kubetest-version': 'kubetest2 version 9560e3922fc039b76e6f3bab9b9711c38ac6d486', 'tester-version': '9560e3922fc039b76e6f3bab9b9711c38ac6d486'}, 'result': 'SUCCESS', 'revision': 'master'}
>>> job_version = finished["metadata"].get("job-version") or finished["metadata"].get("revision")
>>> print(job_version)
None
>>> job_version = finished["metadata"].get("job-version") or finished.get("revision")
>>> print(job_version)
master
```