### PR TITLE
Switch to newer structure of links for KGCL log files

### DIFF
--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -383,7 +383,9 @@ def kgcl_version(job):
     """
     finished_url = GCS_LOGS + KGCL_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"].get("job-version") or finished.get("revision")
+    job_version = finished["metadata"].get("job-version")
+    if not job_version:
+        raise ValueError("Could not find job_version", finished_url)
 
     match = re.match("^v([0-9.]+)-",job_version)
     if match is None:
@@ -399,7 +401,9 @@ def kgcl_commit(job):
     # we want the end of the string, after the '+'. A commit should only be numbers and letters
     finished_url = GCS_LOGS + KGCL_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"].get("job-version") or finished.get("revision")
+    job_version = finished["metadata"].get("job-version")
+    if not job_version:
+        raise ValueError("Could not find job_version", finished_url)
 
     match = re.match(".+\+([0-9a-zA-Z]+)$",job_version)
     if match is None:
@@ -442,7 +446,9 @@ def kegg_version(job):
     """
     finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"].get("job-version") or finished.get("revision")
+    job_version = finished["metadata"].get("job-version")
+    if not job_version:
+        raise ValueError("Could not find job_version", finished_url)
 
     match = re.match("^v([0-9.]+)-",job_version)
     if match is None:
@@ -458,7 +464,9 @@ def kegg_commit(job):
     # we want the end of the string, after the '+'. A commit should only be numbers and letters
     finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["metadata"].get("job-version") or finished.get("revision")
+    job_version = finished["metadata"].get("job-version")
+    if not job_version:
+        raise ValueError("Could not find job_version", finished_url)
     match = re.match(".+\+([0-9a-zA-Z]+)$",job_version)
     if match is None:
         raise ValueError("Could not find commit in given job_version.", job_version)

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -410,7 +410,7 @@ def kgcl_commit(job):
 
 def kgcl_loglinks(job):
     """Return all audit log links for KGCL bucket"""
-    artifacts_url = ARTIFACTS_PATH + KGCL_BUCKET + '/' +  job + '/' + 'artifacts'
+    artifacts_url = ARTIFACTS_PATH + KGCL_BUCKET + '/' +  job + '/' + 'artifacts' + '/' + 'cluster-logs'
     soup = get_html(artifacts_url)
     master_link = soup.find(href=re.compile("master"))
     master_soup = get_html("https://gcsweb.k8s.io" + master_link['href'])


### PR DESCRIPTION
Under artifacts directory, with newer kubetest2, there is another directory... see example:
https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/logs/ci-kubernetes-gce-conformance-latest/1964102933159088128/artifacts/

under `artifacts` you will see `cluster-logs` and under that ywou will see the master + minion logs:
https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/logs/ci-kubernetes-gce-conformance-latest/1964102933159088128/artifacts/cluster-logs/

So we should update the code we have to the newer structure.
